### PR TITLE
File formats

### DIFF
--- a/.github/workflows/bundle.yml
+++ b/.github/workflows/bundle.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions-rust-lang/setup-rust-toolchain@v1
       - name: Install Dioxus 📈
-        run: install dioxus-cli --version 0.7.3 --locked
+        run: cargo install dioxus-cli --version 0.7.3 --locked
       - name: Create bundle
         run: dx bundle -p sciwin --desktop --release
       - uses: actions/upload-artifact@v5
@@ -55,7 +55,7 @@ jobs:
             libayatana-appindicator3-dev \
             librsvg2-dev
       - name: Install Dioxus 📈
-        run: install dioxus-cli --version 0.7.3 --locked
+        run: cargo install dioxus-cli --version 0.7.3 --locked
       - name: Create bundle
         run: dx bundle -p sciwin --desktop --release
       - uses: actions/upload-artifact@v5

--- a/.github/workflows/bundle.yml
+++ b/.github/workflows/bundle.yml
@@ -17,7 +17,7 @@ jobs:
       - uses: actions/checkout@v5
       - uses: actions-rust-lang/setup-rust-toolchain@v1
       - name: Install Dioxus 📈
-        run: cargo install dioxus-cli
+        run: install dioxus-cli --version 0.7.3 --locked
       - name: Create bundle
         run: dx bundle -p sciwin --desktop --release
       - uses: actions/upload-artifact@v5
@@ -55,7 +55,7 @@ jobs:
             libayatana-appindicator3-dev \
             librsvg2-dev
       - name: Install Dioxus 📈
-        run: cargo install dioxus-cli
+        run: install dioxus-cli --version 0.7.3 --locked
       - name: Create bundle
         run: dx bundle -p sciwin --desktop --release
       - uses: actions/upload-artifact@v5

--- a/packages/core/Cargo.toml
+++ b/packages/core/Cargo.toml
@@ -16,9 +16,12 @@ pathdiff.workspace = true
 rand.workspace = true
 serde.workspace = true
 serde_yaml.workspace = true
+serde_json.workspace = true
 tempfile = { workspace = true }
 toml.workspace = true
 toml_edit.workspace = true
+urlencoding.workspace = true
+reqwest.workspace = true
 
 semver = { version = "1.0.26", features = ["serde"] }
 shlex = "1.3.0"

--- a/packages/core/Cargo.toml
+++ b/packages/core/Cargo.toml
@@ -24,6 +24,7 @@ semver = { version = "1.0.26", features = ["serde"] }
 shlex = "1.3.0"
 slugify = "0.1.0"
 smart-default = "0.7.1"
+file_type = "0.8.11"
 
 [dev-dependencies]
 calamine = "0.32.0"

--- a/packages/core/src/parser/inputs.rs
+++ b/packages/core/src/parser/inputs.rs
@@ -8,13 +8,14 @@ use commonwl::{
 use rand::{distr::Alphanumeric, Rng};
 use serde_yaml::Value;
 use slugify::slugify;
+use crate::parser::find_mimetype; 
 
 pub(crate) fn get_inputs(args: &[&str]) -> Vec<CommandInputParameter> {
     let mut inputs = vec![];
     let mut i = 0;
     while i < args.len() {
         let arg = args[i];
-        let input: CommandInputParameter;
+        let mut input: CommandInputParameter;
         if arg.starts_with('-') {
             if i + 1 < args.len() && !args[i + 1].starts_with('-') {
                 //is not a flag, as next one is a value
@@ -25,6 +26,10 @@ pub(crate) fn get_inputs(args: &[&str]) -> Vec<CommandInputParameter> {
             }
         } else {
             input = get_positional(arg, i.try_into().unwrap());
+        }
+        if matches!(input.type_, CWLType::File) && let Some(loc) = get_location(&input) {
+            let mime = find_mimetype(&loc);
+            input = input.with_format(&mime);
         }
         inputs.push(input);
         i += 1;
@@ -123,12 +128,22 @@ pub(crate) fn add_fixed_inputs(tool: &mut CommandLineTool, inputs: &[&str]) -> R
             _ => DefaultValue::Any(serde_yaml::from_str(input)?),
         };
         let id = slugify!(input, separator = "_");
-
-        tool.inputs
-            .push(CommandInputParameter::default().with_id(&id).with_type(type_).with_default_value(default));
+        let mut param = CommandInputParameter::default().with_id(&id).with_type(type_.clone()).with_default_value(default);
+        if matches!(type_, CWLType::File) {
+            let mime = find_mimetype(input);
+            param = param.with_format(&mime);
+        }
+        tool.inputs.push(param);
     }
 
     Ok(())
+}
+
+fn get_location(param: &CommandInputParameter) -> Option<String> {
+    match &param.default {
+        Some(DefaultValue::File(file)) => file.location.clone(),
+        _ => None,
+    }
 }
 
 #[cfg(test)]

--- a/packages/core/src/parser/inputs.rs
+++ b/packages/core/src/parser/inputs.rs
@@ -8,7 +8,7 @@ use commonwl::{
 use rand::{distr::Alphanumeric, Rng};
 use serde_yaml::Value;
 use slugify::slugify;
-use crate::parser::find_mimetype; 
+use crate::parser::find_edam_format; 
 
 pub(crate) fn get_inputs(args: &[&str]) -> Vec<CommandInputParameter> {
     let mut inputs = vec![];
@@ -28,8 +28,8 @@ pub(crate) fn get_inputs(args: &[&str]) -> Vec<CommandInputParameter> {
             input = get_positional(arg, i.try_into().unwrap());
         }
         if matches!(input.type_, CWLType::File) && let Some(loc) = get_location(&input) {
-            let mime = find_mimetype(&loc);
-            input = input.with_format(&mime);
+            let edam_format = find_edam_format(&loc);
+            input = input.with_format(&edam_format);
         }
         inputs.push(input);
         i += 1;
@@ -130,8 +130,8 @@ pub(crate) fn add_fixed_inputs(tool: &mut CommandLineTool, inputs: &[&str]) -> R
         let id = slugify!(input, separator = "_");
         let mut param = CommandInputParameter::default().with_id(&id).with_type(type_.clone()).with_default_value(default);
         if matches!(type_, CWLType::File) {
-            let mime = find_mimetype(input);
-            param = param.with_format(&mime);
+            let edam_format = find_edam_format(input);
+            param = param.with_format(&edam_format);
         }
         tool.inputs.push(param);
     }

--- a/packages/core/src/parser/mod.rs
+++ b/packages/core/src/parser/mod.rs
@@ -1,6 +1,9 @@
 use commonwl::{prelude::*, requirements::WorkDirItem};
 use std::{fs, path::Path};
 use file_type::FileType;
+use reqwest::{self, blocking::Client};
+use serde_json::{Value};
+use urlencoding::encode;
 
 mod inputs;
 mod outputs;
@@ -14,6 +17,11 @@ pub static SCRIPT_EXECUTORS: &[&str] = &["python", "python3", "R", "Rscript", "n
 pub static SCRIPT_MODIFIERS: &[&str] = &["-e", "-m"];
 
 pub(crate) static BAD_WORDS: &[&str] = &["sql", "postgres", "mysql", "password"];
+
+const ONTOLOGY_API_BASE: &str = "https://api.terminology.tib.eu/api/select";
+const ONTOLOGY_API_ONT: &str = "edam";
+const ONTOLOGY_API_FIELD_LIST: &str = "iri,label,short_form,description,type,ontology_name";
+const ONTOLOGY_API_PARENT: &str = "http://edamontology.org/format_1915";
 
 pub(crate) fn parse_command_line(commands: &[&str]) -> CommandLineTool {
     let base_command = get_base_command(commands);
@@ -144,6 +152,68 @@ fn split_vec_at<T: PartialEq + Clone, C: AsRef<[T]>>(vec: C, split_at: &T) -> (V
     } else {
         (slice.to_vec(), vec![])
     }
+}
+
+fn query_ontology_api(ext: &str) -> Option<String> {
+    let encoded_ext = encode(ext);
+    let parameters = format!(
+        "q={}&ontology={}&fieldList={}&childrenOf={}",
+        encoded_ext,
+        ONTOLOGY_API_ONT,
+        ONTOLOGY_API_FIELD_LIST,
+        ONTOLOGY_API_PARENT
+    );
+    let url = format!("{}?{}", ONTOLOGY_API_BASE, parameters);
+    let client = Client::new();
+    let response = match client.get(&url).send() {
+        Ok(res) => res,
+        Err(e) => {
+            eprintln!("Request failed: {}", e);
+            return None;
+        }
+    };
+    let body = match response.text() {
+        Ok(body) => body,
+        Err(e) => {
+            eprintln!("Failed to read response body: {}", e);
+            return None;
+        }
+    };
+    let json: Value = match serde_json::from_str(&body) {
+        Ok(val) => val,
+        Err(e) => {
+            eprintln!("Failed to parse JSON: {} | Raw body: {}", e, body);
+            return None;
+        }
+    };
+    let Some(docs) = json["response"]["docs"].as_array() else {
+        eprintln!("No 'response.docs' array in JSON");
+        return None;
+    };
+    if docs.is_empty() {
+        return None;
+    }
+    let iri = match docs[0]["iri"].as_str() {
+        Some(iri) => iri.to_string(),
+        None => {
+            eprintln!("No 'iri' field in first result");
+            return None;
+        }
+    };
+    Some(iri)
+}
+
+pub fn find_edam_format(filename: &str) -> String {
+    let ext_opt = Path::new(filename).extension().and_then(|e| e.to_str());
+    if let Some(ext) = ext_opt {
+        let ext_lower = ext.to_lowercase();
+        //first try to find format with API 
+         if let Some(iri) = query_ontology_api(&ext_lower) {
+            return iri;
+        }
+    }
+    //if not found, fallback to mimetype
+    find_mimetype(filename)
 }
 
 fn find_mimetype(filename: &str) -> String {

--- a/packages/core/src/parser/mod.rs
+++ b/packages/core/src/parser/mod.rs
@@ -377,7 +377,7 @@ mod tests {
         let root = env::var("CARGO_MANIFEST_DIR").unwrap();
         copy_dir(Path::new(&root).join("../../testdata/module"), path.join("module")).unwrap();
 
-        let current = env::current_dir().unwrap();
+        let original_dir = Path::new(&root).parent().unwrap().to_path_buf();
         env::set_current_dir(path).unwrap();
 
         let cwl = parse_command("python3 -m module --what ever");
@@ -385,6 +385,6 @@ mod tests {
         
         assert!(run_command(&cwl, &mut RuntimeEnvironment::default()).is_ok());   
         assert_eq!(cwl.base_command, Command::Multiple(vec!["python3".to_string(), "-m".to_string(),  "module".to_string() ]));
-        env::set_current_dir(current).unwrap();
+        env::set_current_dir(original_dir).unwrap();
     }
 }

--- a/packages/core/src/parser/mod.rs
+++ b/packages/core/src/parser/mod.rs
@@ -1,5 +1,6 @@
 use commonwl::{prelude::*, requirements::WorkDirItem};
 use std::{fs, path::Path};
+use file_type::FileType;
 
 mod inputs;
 mod outputs;
@@ -143,6 +144,15 @@ fn split_vec_at<T: PartialEq + Clone, C: AsRef<[T]>>(vec: C, split_at: &T) -> (V
     } else {
         (slice.to_vec(), vec![])
     }
+}
+
+fn find_mimetype(filename: &str) -> String {
+    let ext_opt = Path::new(filename).extension().and_then(|e| e.to_str());
+    ext_opt
+        .and_then(|ext| FileType::from_extension(ext).first())
+        .and_then(|ft| ft.media_types().first())
+        .map(|s| (*s).to_string())
+        .unwrap_or_default()
 }
 
 #[cfg(test)]

--- a/packages/core/src/parser/outputs.rs
+++ b/packages/core/src/parser/outputs.rs
@@ -4,7 +4,7 @@ use commonwl::{
     outputs::{CommandOutputBinding, CommandOutputParameter},
 };
 use std::path::Path;
-use crate::parser::find_mimetype;
+use crate::parser::find_edam_format;
 
 pub(crate) fn get_outputs(files: &[String]) -> Vec<CommandOutputParameter> {
     files
@@ -24,8 +24,8 @@ pub(crate) fn get_outputs(files: &[String]) -> Vec<CommandOutputParameter> {
                     ..Default::default()
                 });
             if is_file {
-                let mime = find_mimetype(f);
-                out = out.with_format(&mime);
+                let edam_format = find_edam_format(f);
+                out = out.with_format(&edam_format);
             }
             out
         })
@@ -43,7 +43,7 @@ mod tests {
             CommandOutputParameter::default()
                 .with_type(CWLType::File)
                 .with_id("my-file")
-                .with_format("text/plain")
+                .with_format("http://edamontology.org/format_2330")
                 .with_binding(CommandOutputBinding {
                     glob: Some(commonwl::SingularPlural::Singular("my-file.txt".to_string())),
                     ..Default::default()
@@ -51,7 +51,7 @@ mod tests {
             CommandOutputParameter::default()
                 .with_type(CWLType::File)
                 .with_id("archive")
-                .with_format("application/gzip")
+                .with_format("http://edamontology.org/format_3989")
                 .with_binding(CommandOutputBinding {
                     glob: Some(commonwl::SingularPlural::Singular("archive.tar.gz".to_string())),
                     ..Default::default()

--- a/packages/core/src/parser/outputs.rs
+++ b/packages/core/src/parser/outputs.rs
@@ -4,24 +4,30 @@ use commonwl::{
     outputs::{CommandOutputBinding, CommandOutputParameter},
 };
 use std::path::Path;
+use crate::parser::find_mimetype;
 
 pub(crate) fn get_outputs(files: &[String]) -> Vec<CommandOutputParameter> {
     files
         .iter()
         .map(|f| {
-            let filename = get_filename_without_extension(f);
-            let output_type = if Path::new(f).extension().is_some() {
+            let is_file = Path::new(f).extension().is_some();
+            let output_type = if is_file {
                 CWLType::File
             } else {
                 CWLType::Directory
             };
-            CommandOutputParameter::default()
+            let mut out = CommandOutputParameter::default()
+                .with_id(&get_filename_without_extension(f))
                 .with_type(output_type)
-                .with_id(&filename)
                 .with_binding(CommandOutputBinding {
-                    glob: Some(SingularPlural::Singular(f.to_string())),
+                    glob: Some(SingularPlural::Singular(f.clone())),
                     ..Default::default()
-                })
+                });
+            if is_file {
+                let mime = find_mimetype(f);
+                out = out.with_format(&mime);
+            }
+            out
         })
         .collect()
 }
@@ -37,6 +43,7 @@ mod tests {
             CommandOutputParameter::default()
                 .with_type(CWLType::File)
                 .with_id("my-file")
+                .with_format("text/plain")
                 .with_binding(CommandOutputBinding {
                     glob: Some(commonwl::SingularPlural::Singular("my-file.txt".to_string())),
                     ..Default::default()
@@ -44,6 +51,7 @@ mod tests {
             CommandOutputParameter::default()
                 .with_type(CWLType::File)
                 .with_id("archive")
+                .with_format("application/gzip")
                 .with_binding(CommandOutputBinding {
                     glob: Some(commonwl::SingularPlural::Singular("archive.tar.gz".to_string())),
                     ..Default::default()

--- a/packages/core/src/workflow.rs
+++ b/packages/core/src/workflow.rs
@@ -1,5 +1,5 @@
 use anyhow::{Context, Result};
-use commonwl::{StringOrDocument, execution::io::create_and_write_file, format::format_cwl, load_doc, prelude::*};
+use commonwl::{StringOrDocument, execution::io::create_and_write_file, format::format_cwl, load_doc, load_tool, prelude::*};
 use std::{fs, path::Path};
 
 pub fn create_workflow(filename: impl AsRef<Path>, force: bool) -> Result<String> {
@@ -126,8 +126,40 @@ pub fn add_workflow_step_connection(
     let from_filename = from_filename.as_ref();
     let to_filename = to_filename.as_ref();
 
+    let from_cwl = load_doc(from_filename).map_err(|e| anyhow::anyhow!("Failed to load CWL document: {e}"))?;
+    let to_cwl = load_doc(to_filename).map_err(|e| anyhow::anyhow!("Failed to load CWL document: {e}"))?;
+    let from_tool = load_tool(from_filename).map_err(|e| anyhow::anyhow!("Failed to load tool definition: {e}"))?;
+    let to_tool = load_tool(to_filename).map_err(|e| anyhow::anyhow!("Failed to load tool definition: {e}"))?;
+
+    let from_output = from_tool.outputs.iter().find(|p| p.id == from_slot_id)
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "Tool `{}` has no output `{}`. Available outputs: {:?}",
+                from_name,
+                from_slot_id,
+                from_tool.outputs.iter().map(|p| &p.id).collect::<Vec<_>>()
+            )
+        })?;
+
+    let to_input = to_tool.inputs.iter().find(|p| p.id == to_slot_id)
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "Tool `{}` has no input `{}`. Available inputs: {:?}",
+                to_name,
+                to_slot_id,
+                to_tool.inputs.iter().map(|p| &p.id).collect::<Vec<_>>()
+            )
+        })?;
+
+    // check format compatibility
+    if let (Some(to_format), Some(from_format)) = (&to_input.format, &from_output.format) && to_format != from_format {
+        anyhow::bail!(
+            "Cannot connect `{from_name}` → `{to_name}`: format mismatch. \
+                Output `{from_slot_id}` has format `{from_format}`, \
+                but input `{to_slot_id}` expects `{to_format}`."
+        );
+    }
     if !workflow.has_step(from_name) {
-        let from_cwl = load_doc(from_filename).map_err(|e| anyhow::anyhow!("Failed to load CWL document: {e}"))?;
         let from_outputs = from_cwl.get_output_ids();
         if !from_outputs.contains(&from_slot_id.to_string()) {
             anyhow::bail!(
@@ -144,7 +176,6 @@ pub fn add_workflow_step_connection(
 
     //check if step exists
     if !workflow.has_step(to_name) {
-        let to_cwl = load_doc(to_filename).map_err(|e| anyhow::anyhow!("Failed to load CWL document: {e}"))?;
         add_workflow_step(workflow, to_name, to_filename, &to_cwl);
     }
 

--- a/packages/cwl_core/src/inputs.rs
+++ b/packages/cwl_core/src/inputs.rs
@@ -47,6 +47,11 @@ impl CommandInputParameter {
         self.input_binding = Some(binding);
         self
     }
+
+    pub fn with_format(mut self, format: &str) -> Self {
+        self.format = Some(format.to_string());
+        self
+    }
 }
 
 impl Identifiable for CommandInputParameter {

--- a/packages/cwl_core/src/outputs.rs
+++ b/packages/cwl_core/src/outputs.rs
@@ -30,6 +30,10 @@ impl CommandOutputParameter {
         self.output_binding = Some(binding);
         self
     }
+    pub fn with_format(mut self, format: &str) -> Self {
+        self.format = Some(format.to_string());
+        self
+    }
 }
 
 impl Identifiable for CommandOutputParameter {


### PR DESCRIPTION
Infer file formats for CWL files. 

Currently: 
- Infer file format for inputs/outputs from EDAM (could change that) when CommandLineTools are created 
- Prevent connection of two steps with incompatible formats

Questions: 
- Do we want to display file format in Studio somewhere? 
- Are users allowed to change the format, e.g. in Studio through pencil? We could combine this a general step/node description that can be given by user
- Do we also want to add a label to inputs/outputs, e.g. label: Aligned sequences in BAM format